### PR TITLE
Implement schema validation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "tests/googletest"]
 	path = tests/googletest
 	url = https://github.com/google/googletest
+[submodule "extern/valijson"]
+	path = extern/valijson
+	url = https://github.com/tristanpenman/valijson

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,8 @@ find_package(bzip2)
 
 set( INCLUDE_DIR include )
 set( VALIJSON_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/extern/valijson/include" )
-include_directories( ${INCLUDE_DIR} ${YAML_INCLUDE_DIR} ${VALIJSON_INCLUDE_DIR} )
+include_directories( ${INCLUDE_DIR} ${YAML_INCLUDE_DIR} )
+include_directories( SYSTEM ${VALIJSON_INCLUDE_DIR} )
 
 set(asdf_c_flags ${CMAKE_C_FLAGS})
 set(asdf_cxx_flags ${CMAKE_CXX_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,9 @@ set_target_properties(asdf-cpp PROPERTIES
   COMPILE_FLAGS "${asdf_c_flags} ${asdf_cxx_flags}"
 )
 
+add_executable( validator src/validation.cpp )
+target_link_libraries( validator yaml-cpp )
+
 if (${ZLIB_FOUND})
     target_compile_definitions(asdf-cpp PRIVATE HAS_ZLIB=1)
     target_include_directories(asdf-cpp PRIVATE ${ZLIB_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,8 @@ find_package(zlib)
 find_package(bzip2)
 
 set( INCLUDE_DIR include )
-include_directories( ${INCLUDE_DIR} ${YAML_INCLUDE_DIR} )
+set( VALIJSON_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/extern/valijson/include" )
+include_directories( ${INCLUDE_DIR} ${YAML_INCLUDE_DIR} ${VALIJSON_INCLUDE_DIR} )
 
 set(asdf_c_flags ${CMAKE_C_FLAGS})
 set(asdf_cxx_flags ${CMAKE_CXX_FLAGS})

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1,0 +1,233 @@
+#include <string>
+#include <cstdio>
+#include <cstdint>
+
+#include <yaml-cpp/yaml.h>
+
+#include <valijson/schema.hpp>
+#include <valijson/schema_parser.hpp>
+#include <valijson/adapters/basic_adapter.hpp>
+
+
+using valijson::adapters::Adapter;
+using valijson::adapters::BasicAdapter;
+using valijson::adapters::FrozenValue;
+
+
+class YamlCppArray
+{
+
+};
+
+
+class YamlCppObjectMember
+{
+
+};
+
+
+class YamlCppObject
+{
+
+};
+
+
+class YamlCppFrozenNode: public FrozenValue
+{
+    public:
+        /**
+         * @brief  Make a copy of a YAML Node
+         *
+         * @param  source  the YAML node to be copied
+         */
+        explicit YamlCppFrozenNode(const YAML::Node &source) : node(source) { }
+
+        virtual FrozenValue * clone() const
+        {
+            return new YamlCppFrozenNode(node);
+        }
+
+        virtual bool equalTo(const Adapter &other, bool strict) const;
+
+private:
+
+    /// Stored YAML node
+    YAML::Node node;
+
+};
+
+
+/**
+ * @brief   Light weight wrapper for a YAML node.
+ *
+ * This class is passed as an argument to the BasicAdapter template class, and
+ * is used to provide access to a YAML node. This class is responsible for the
+ * mechanics of actually reading a YAML node, whereas the BasicAdapter class is
+ * responsible for the semantics of type comparisons and conversions.
+ *
+ * The functions that need to be provided by this class are defined implicitly
+ * by the implementation of the BasicAdapter template class.
+ *
+ * @see BasicAdapter
+ */
+class YamlCppNode
+{
+    public:
+
+        YamlCppNode() : node(emptyObject()) { }
+        YamlCppNode(const YAML::Node &node) : node(node) { }
+
+        /**
+         * @brief   Create a new YamlCppFrozenNode instance that contains the
+         *          value referenced by this YamlCppNode instance.
+         *
+         * @returns pointer to a new YamlCppFrozenNode instance, belonging to
+         *          the caller.
+         */
+        FrozenValue * freeze() const
+        {
+            return new YamlCppFrozenNode(node);
+        }
+
+        /*
+         * YAML does not assign strict types to node values. This means that
+         * many of the "is*" and "get*" methods below will also return false.
+         */
+        static bool hasStrictTypes()
+        {
+            return false;
+        }
+
+        bool getObjectSize(size_t &result) const
+        {
+            if (node.IsNull())
+            {
+                return false;
+            }
+
+            result = node.size();
+            return true;
+        }
+
+        bool getArraySize(size_t &result) const
+        {
+            return getObjectSize(result);
+        }
+
+        bool getBool(bool &) const
+        {
+            return false;
+        }
+
+        bool getDouble(double &) const
+        {
+            return false;
+        }
+
+        bool getInteger(int64_t &) const
+        {
+            return false;
+        }
+
+        bool getString(std::string &result) const
+        {
+            result = node.as<std::string>();
+            return true;
+        }
+
+        /**
+         * @brief   Optionally return a YamlCppArray instance.
+         *
+         * If the referenced YAML node is an array, this function will return a
+         * std::optional containing a YamlCppArray instance referencing the
+         * array.
+         *
+         * Otherwise it will return an empty optional.
+         */
+        opt::optional<YamlCppArray> getArrayOptional() const
+        {
+            if (isArray()) {
+                return opt::make_optional(YamlCppArray(node));
+            }
+
+            return opt::optional<YamlCppArray>();
+        }
+
+        bool isArray() const
+        {
+            return node.IsSequence() && !node.IsNull();
+        }
+
+        bool isInteger() const
+        {
+            return false;
+        }
+
+        bool isDouble() const
+        {
+            return false;
+        }
+
+        bool isNumber() const
+        {
+            return false;
+        }
+
+        bool isBool() const
+        {
+            return false;
+        }
+
+        bool isString() const
+        {
+            return false;
+        }
+
+        bool isObject() const
+        {
+            return false;
+        }
+
+        bool isNull() const
+        {
+            return node.IsNull();
+        }
+
+    private:
+
+        static const YAML::Node& emptyObject()
+        {
+            static const YAML::Node object;
+            return object;
+        }
+
+        const YAML::Node &node;
+};
+
+
+class YamlCppAdapter:
+    public BasicAdapter<YamlCppAdapter,
+                        YamlCppArray,
+                        YamlCppObjectMember,
+                        YamlCppObject,
+                        YamlCppNode>
+{
+    public:
+
+        YamlCppAdapter() : BasicAdapter() { }
+        YamlCppAdapter(const YAML::Node &node) : BasicAdapter(node) { }
+
+};
+
+
+int main(int argc, char **argv)
+{
+    if (argc != 2)
+    {
+        fprintf(stderr, "USAGE: %s <schema> <document>\n", argv[0]);
+        return 1;
+    }
+
+    YAML::Node schema = YAML::LoadFile(argv[1]);
+    YamlCppAdapter schemaAdapter(schema);
+}

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -383,8 +383,17 @@ class YamlCppAdapter:
     public:
 
         YamlCppAdapter() : BasicAdapter() { }
-        YamlCppAdapter(const YAML::Node &node) : BasicAdapter(node) { }
+        YamlCppAdapter(const YAML::Node &node) : BasicAdapter(node), node(node)
+            { }
 
+
+        bool maybeString() const
+        {
+            return !(node.isObject() || node.isArray()) ;
+        }
+
+    private:
+        const YamlCppNode node;
 };
 
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -507,7 +507,7 @@ public:
      */
     YamlCppObjectMember operator*() const
     {
-        return YamlCppObjectMember(itr->first.as<std::string>(), *itr);
+        return YamlCppObjectMember(itr->first.as<std::string>(), itr->second);
     }
 
     DerefProxy<YamlCppObjectMember> operator->() const

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -507,7 +507,7 @@ public:
      */
     YamlCppObjectMember operator*() const
     {
-        return YamlCppObjectMember("", *itr);
+        return YamlCppObjectMember(itr->first.as<std::string>(), itr->second);
     }
 
     DerefProxy<YamlCppObjectMember> operator->() const

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -621,6 +621,10 @@ int main(int argc, char **argv)
         return 1;
     }
 
-    YAML::Node schema = YAML::LoadFile(argv[1]);
-    YamlCppAdapter schemaAdapter(schema);
+    YAML::Node yaml_schema = YAML::LoadFile(argv[1]);
+
+    valijson::Schema schema;
+    valijson::SchemaParser parser;
+    YamlCppAdapter schemaAdapter(yaml_schema);
+    parser.populateSchema(schemaAdapter, schema);
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -392,6 +392,28 @@ class YamlCppAdapter:
             return !(node.isObject() || node.isArray()) ;
         }
 
+        std::string asString() const
+        {
+            std::string result;
+            if (asString(result))
+            {
+                return result;
+            }
+
+            throw std::runtime_error("YAML value cannot be cast to string");
+        }
+
+        bool asString(std::string &result) const
+        {
+            if (maybeString())
+            {
+                node.getString(result);
+                return true;
+            }
+
+            return false;
+        }
+
     private:
         const YamlCppNode node;
 };

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -392,23 +392,6 @@ class YamlCppAdapter:
             return !(node.isObject() || node.isArray()) ;
         }
 
-        virtual bool maybeBool() const
-        {
-            if (maybeString())
-            {
-                std::string stringValue;
-                if (node.getString(stringValue))
-                {
-                    if (stringValue.compare("true") == 0 || stringValue.compare("false") == 0)
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
         std::string asString() const
         {
             std::string result;
@@ -429,32 +412,6 @@ class YamlCppAdapter:
             }
 
             return false;
-        }
-
-        bool asBool(bool &result) const
-        {
-            std::string s;
-            if (node.getString(s)) {
-                if (s.compare("true") == 0) {
-                    result = true;
-                    return true;
-                } else if (s.compare("false") == 0) {
-                    result = false;
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        bool asBool() const
-        {
-            bool result;
-            if (asBool(result)) {
-                return result;
-            }
-
-            throw std::runtime_error("JSON value cannot be cast to a boolean.");
         }
 
     private:

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -590,13 +590,11 @@ inline YamlCppObjectMemberIterator YamlCppObject::end() const
 inline YamlCppObjectMemberIterator YamlCppObject::find(
     const std::string &propertyName) const
 {
-#if 0
     for (auto itr = node.begin(); itr != node.end(); ++itr) {
-        if (itr->first == propertyName) {
+        if (itr->first.as<std::string>() == propertyName) {
             return itr;
         }
     }
-#endif
 
     return node.end();
 }
@@ -610,12 +608,5 @@ int main(int argc, char **argv)
     }
 
     YAML::Node schema = YAML::LoadFile(argv[1]);
-    std::cout << schema << std::endl;
-    std::cout << schema.Scalar() << std::endl;
-    for (auto itr = schema.begin(); itr != schema.end(); ++itr)
-    {
-        std::cout << itr->first << std::endl;
-    }
-
     YamlCppAdapter schemaAdapter(schema);
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -353,7 +353,7 @@ class YamlCppNode
 
         bool isObject() const
         {
-            return !isNull() && node.IsMap();
+            return node.IsMap() && !node.IsNull();
         }
 
         bool isNull() const

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -392,6 +392,23 @@ class YamlCppAdapter:
             return !(node.isObject() || node.isArray()) ;
         }
 
+        virtual bool maybeBool() const
+        {
+            if (maybeString())
+            {
+                std::string stringValue;
+                if (node.getString(stringValue))
+                {
+                    if (stringValue.compare("true") == 0 || stringValue.compare("false") == 0)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
         std::string asString() const
         {
             std::string result;
@@ -412,6 +429,32 @@ class YamlCppAdapter:
             }
 
             return false;
+        }
+
+        bool asBool(bool &result) const
+        {
+            std::string s;
+            if (node.getString(s)) {
+                if (s.compare("true") == 0) {
+                    result = true;
+                    return true;
+                } else if (s.compare("false") == 0) {
+                    result = false;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        bool asBool() const
+        {
+            bool result;
+            if (asBool(result)) {
+                return result;
+            }
+
+            throw std::runtime_error("JSON value cannot be cast to a boolean.");
         }
 
     private:

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -644,6 +644,35 @@ struct valijson::adapters::AdapterTraits<YamlCppAdapter>
 };
 
 
+class AsdfSchemaParser : public valijson::SchemaParser
+{
+    /* Overridden from implementation in Schema parser */
+    opt::optional<std::string> findAbsoluteDocumentUri(
+            const opt::optional<std::string> resolutionScope,
+            const opt::optional<std::string> documentUri)
+    {
+        namespace internal = valijson::internal;
+
+        std::string base = "/Users/ddavella/asdf/asdf-standard/schemas/stsci.edu/asdf/core/";
+        return base + documentUri.value() + ".yaml";
+    }
+};
+
+
+const YAML::Node * fetchYamlDoc(const std::string &uri)
+{
+    YAML::Node temp = YAML::LoadFile(uri);
+    YAML::Node *node = new YAML::Node(temp);
+    return node;
+}
+
+
+void freeYamlDoc(const YAML::Node *node)
+{
+    delete node;
+}
+
+
 int main(int argc, char **argv)
 {
     if (argc != 3)
@@ -655,7 +684,7 @@ int main(int argc, char **argv)
     YAML::Node yaml_schema = YAML::LoadFile(argv[1]);
 
     valijson::Schema schema;
-    valijson::SchemaParser parser;
+    AsdfSchemaParser parser;
     YamlCppAdapter schemaAdapter(yaml_schema);
-    parser.populateSchema(schemaAdapter, schema);
+    parser.populateSchema(schemaAdapter, schema, fetchYamlDoc, freeYamlDoc);
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -353,7 +353,7 @@ class YamlCppNode
 
         bool isObject() const
         {
-            return isNull() && node.IsMap();
+            return !isNull() && node.IsMap();
         }
 
         bool isNull() const

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -225,7 +225,7 @@ class YamlCppNode
     public:
 
         YamlCppNode() : node(emptyObject()) { }
-        YamlCppNode(const YAML::Node &node) : node(node) { }
+        YamlCppNode(const YAML::Node node) : node(node) { }
 
         /**
          * @brief   Create a new YamlCppFrozenNode instance that contains the
@@ -369,7 +369,7 @@ class YamlCppNode
             return object;
         }
 
-        const YAML::Node &node;
+        const YAML::Node node;
 };
 
 
@@ -382,8 +382,8 @@ class YamlCppAdapter:
 {
     public:
 
-        YamlCppAdapter() : BasicAdapter() { }
-        YamlCppAdapter(const YAML::Node &node) : BasicAdapter(node), node(node)
+        YamlCppAdapter() : BasicAdapter(), node() { }
+        YamlCppAdapter(const YAML::Node node) : BasicAdapter(node), node(node)
             { }
 
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -599,6 +599,20 @@ inline YamlCppObjectMemberIterator YamlCppObject::find(
     return node.end();
 }
 
+
+/// Specialization of the AdapterTraits template struct for YamlCppAdapter.
+template<>
+struct valijson::adapters::AdapterTraits<YamlCppAdapter>
+{
+    typedef YAML::Node DocumentType;
+
+    static std::string adapterName()
+    {
+        return "YamlCppAdapter";
+    }
+};
+
+
 int main(int argc, char **argv)
 {
     if (argc != 3)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -507,7 +507,7 @@ public:
      */
     YamlCppObjectMember operator*() const
     {
-        return YamlCppObjectMember(itr->first.as<std::string>(), itr->second);
+        return YamlCppObjectMember(itr->first.as<std::string>(), *itr);
     }
 
     DerefProxy<YamlCppObjectMember> operator->() const


### PR DESCRIPTION
I am creating this PR solely to serve as a reference for future efforts to implement schema validation. I think this approach is probably dead in the water since `valijson` seems to no longer be maintained. It's possible that this work could continue by either forking or externing the `valijson` package, although at some point it might just be easier to write a custom JSON Schema validator for this package.