### PR TITLE
Add virtual destructor for clang compiler

### DIFF
--- a/include/asdf-cpp/block_manager.hpp
+++ b/include/asdf-cpp/block_manager.hpp
@@ -14,7 +14,7 @@ namespace Asdf {
 class GenericBlock {
     public:
         GenericBlock(void) {}
-
+        virtual ~GenericBlock() {};
     private:
         friend class BlockManager;
 


### PR DESCRIPTION
I was unable to compile the c++ code on my mac under clang. This PR adds an emtpy virtual destructor to the `GenericBlock` base class. I think this should enable derived objects to fully destruct, and passes clang:

>Apple LLVM version 10.0.0 (clang-1000.11.45.2)
>Target: x86_64-apple-darwin17.7.0
>Thread model: posix
